### PR TITLE
Locale access through React Context

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, {useState} from 'react';
+import { LocaleContext, locales } from './contexts'
 import Frontpage from './pages/frontpage'
 import NewsArticlePage from './pages/news_article_page'
 import Header from './components/header'
@@ -9,29 +10,34 @@ import {DummyData2} from './components/news/frontpage_news_widget'
 
 
 function App() {
-  return (
-    <div className="App">
 
-        <Header />
+    const [locale, setLocale] = useState(locales.sv)
 
-        <div className="content container">
-            <Switch>
+    return (
+        <div className="App">
+        <LocaleContext.Provider value={locale}>
 
-                <Route path="/newsarticle">
-                    <NewsArticlePage {...DummyData2} />
-                </Route>
+            <Header setLocale={setLocale}/>
 
-                <Route path="/">
-                    <Frontpage />
-                </Route>
+            <div className="content container">
+                <Switch>
 
-            </Switch>
+                    <Route path="/newsarticle">
+                        <NewsArticlePage {...DummyData2} />
+                    </Route>
+
+                    <Route path="/">
+                        <Frontpage />
+                    </Route>
+
+                </Switch>
+            </div>
+
+            <Footer />
+
+        </LocaleContext.Provider>
         </div>
-
-        <Footer />
-
-    </div>
-  );
+    );
 }
 
 export default App;

--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -1,4 +1,5 @@
-import { Button, Container } from '@material-ui/core';
+import { Button, Container, Select } from '@material-ui/core';
+import { LocaleContext, locales } from '../contexts'
 import './header.css'
 import React, { useState } from 'react';
 import { CSSTransition } from 'react-transition-group';
@@ -7,27 +8,43 @@ import { GroupedSearch } from './search-box';
 import HeaderMenu from './HeaderMenu';
 
 
-function Header() {
-  return (
-    <div 
-      className="navbar sticky-top bg-light px-4" 
-      style={{
-        display: "flex",
-        justifyContent: "space-between"
-      }}
-    >
-        <a className="navbar-brand mx-5 text-center" href="/">
-            <img src={logo} width="80" height="80" alt="" />
-            <h2>Fysiksektionen</h2>
-        </a>
-        <div>
-          <div className="mx-4">
-            <GroupedSearch/>
-          </div>
-          <HeaderMenu/>
-        </div>
-      </div>
-  );
+type Props = {
+    setLocale: Function
+}
+
+function Header(props: Props) {
+    return (
+        <LocaleContext.Consumer>
+        {locale => 
+            <div 
+            className="navbar sticky-top bg-light px-4" 
+            style={{
+                display: "flex",
+                justifyContent: "space-between"
+            }}
+            >
+            <a className="navbar-brand mx-5 text-center" href="/">
+                <img src={logo} width="80" height="80" alt="" />
+                <h2>Fysiksektionen</h2>
+            </a>
+            <div>
+            <div className="mx-4">
+                <GroupedSearch/>
+            </div>
+            <HeaderMenu/>
+            </div>
+
+                <Select value={locale.id} onChange={event => {
+                    props.setLocale(locales[event.target.value as string])
+                }}>
+                    {Object.keys(locales).map(key => 
+                        <option value={key}>{locales[key].name}</option>
+                    )}
+                </Select>
+
+        </div>}
+        </LocaleContext.Consumer>
+    );
 }
 
 export default Header;

--- a/client/src/contexts.tsx
+++ b/client/src/contexts.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+type Locale = {
+    id: string,
+    name: string
+}
+
+export const locales: {[key: string]: Locale} = {
+    sv: {
+        id: "sv",
+        name: "Svenska"
+    },
+    en: {
+        id: "en",
+        name: "English"
+    }
+}
+
+export const LocaleContext = React.createContext(
+    locales.sv     // Default
+)


### PR DESCRIPTION
Nu finns en Content Provider inlagd i App() som wrappar runt alla andra delar av sidan, samt en Select-komponent i headern för att byta locale. Vill man i någon subkomponent veta vilken locale som används så använder man en Content Consumer.